### PR TITLE
Fix memory leak when entering hyperspace in HD

### DIFF
--- a/src/uqm/hyper.c
+++ b/src/uqm/hyper.c
@@ -437,9 +437,12 @@ LoadHyperData (void)
 			hyperstars[3] = CaptureDrawable (
 				LoadGraphic (ARI_AMBIENT_MASK_PMAP_ANIM));
 		}
-		npcbubble = CaptureDrawable (LoadGraphic (NPCBUBBLE_MASK_PMAP_ANIM));
-		quasiportal = CaptureDrawable (LoadGraphic (QUASIPORTAL_MASK_PMAP_ANIM));
-        Falayalaralfali  = CaptureDrawable (LoadGraphic (FALAYALARALFALI_MASK_PMAP_ANIM));
+		if (npcbubble == 0)
+			npcbubble = CaptureDrawable (LoadGraphic (NPCBUBBLE_MASK_PMAP_ANIM));
+		if (quasiportal == 0)
+			quasiportal = CaptureDrawable (LoadGraphic (QUASIPORTAL_MASK_PMAP_ANIM));
+		if (Falayalaralfali == 0)
+			Falayalaralfali = CaptureDrawable (LoadGraphic (FALAYALARALFALI_MASK_PMAP_ANIM));
 	}
 	
 	if (hyperstars[0] == 0) {


### PR DESCRIPTION
The hyperspace loading code loaded three resources in HD without checking to see if they were already loaded. Since hyperspace resources are only freed when you quit the game, this leaked a significant amount of memory every time hyperspace was entered except the first.

Possibly solves #6?