### PR TITLE
Properly display RU during first conversation with Hayes at endgame

### DIFF
--- a/src/uqm/sis.c
+++ b/src/uqm/sis.c
@@ -458,7 +458,7 @@ DrawStatusMessage (const UNICODE *pStr)
 		}
 		else if (curMsgMode == SMM_RES_UNITS)
 		{
-			if (GET_GAME_STATE (CHMMR_BOMB_STATE) > 2 || optInfiniteRU) {
+			if (GET_GAME_STATE (CHMMR_BOMB_STATE) >= 2 || optInfiniteRU) {
 				snprintf (buf, sizeof buf, "%s %s",
 						(optWhichMenu == OPT_PC) ?
 							GAME_STRING (STATUS_STRING_BASE + 2)


### PR DESCRIPTION
Previously, the actual, practically-unlimited RU amount would be displayed:
![image](https://user-images.githubusercontent.com/7238529/65576182-4de33d00-df26-11e9-9002-4c6ed51fc7c6.png)
[Here's a save that you can test it with](https://github.com/Serosis/UQM-MegaMod/files/3650940/save.zip) (at Procyon with all required devices).
