### PR TITLE
Fix issues with the Sa-Matra and Druuge AIs' use of WORLD_TO_TURN in HD

### DIFF
--- a/src/uqm/ships/druuge/druuge.c
+++ b/src/uqm/ships/druuge/druuge.c
@@ -212,7 +212,7 @@ druuge_intelligence (ELEMENT *ShipPtr, EVALUATE_DESC *ObjectsOfConcern,
 	if (StarShipPtr->cur_status_flags & SHIP_BEYOND_MAX_SPEED)
 		lpEvalDesc->MoveState = ENTICE;
 	else if (lpEvalDesc->ObjectPtr
-			&& lpEvalDesc->which_turn <= WORLD_TO_TURN (RES_SCALE(MISSILE_RANGE) * 3 / 4))
+			&& lpEvalDesc->which_turn <= WORLD_TO_TURN (MISSILE_RANGE * 3 / 4))
 	{
 		GetElementStarShip (lpEvalDesc->ObjectPtr, &EnemyStarShipPtr);
 		ship_flags = EnemyStarShipPtr->RaceDescPtr->ship_info.ship_flags;

--- a/src/uqm/ships/lastbat/lastbat.c
+++ b/src/uqm/ships/lastbat/lastbat.c
@@ -563,10 +563,10 @@ sentinel_preprocess (ELEMENT *ElementPtr)
 					- (SDWORD)ElementPtr->current.location.y;
 			delta_y = WRAP_DELTA_Y (delta_y);
 
-			if ((num_frames = WORLD_TO_TURN (
+			if ((num_frames = RES_DESCALE (WORLD_TO_TURN (
 					square_root ((long)delta_x * delta_x
 					+ (long)delta_y * delta_y)
-					)) == 0)
+					))) == 0)
 				num_frames = 1;
 
 			TargetVelocity = TargetPtr->velocity;


### PR DESCRIPTION
The Sa-Matra sentinel AI approximated an intercept course by targeting your predicted position in `WORLD_TO_TURN(distance to you)` frames. Since the distance is scaled with resolution, this results in it massively overshooting in HD, making the sentinels much easier to avoid.

The Druuge AI tried to sit still and snipe you if it wasn't moving too fast and its *descaled* distance to you was within 3/4 of its *scaled* missile range. This resulted in it almost never thrusting in HD.