### PR TITLE
Draw correct location when exiting save/load menu at starbase, fixing crash

### DIFF
--- a/src/uqm/gameopt.c
+++ b/src/uqm/gameopt.c
@@ -50,6 +50,8 @@ static COUNT lastUsedSlot;
 
 static NamingCallback *namingCB;
 
+static SISBarDrawFunc *DrawSISBar;
+
 void
 ConfirmSaveLoad (STAMP *MsgStamp)
 {
@@ -606,6 +608,12 @@ void
 SetNamingCallback (NamingCallback *callback)
 {
 	namingCB = callback;
+}
+
+void
+SetSISBarDrawFunc (SISBarDrawFunc *func)
+{
+	DrawSISBar = func;
 }
 
 static BOOLEAN
@@ -1373,15 +1381,20 @@ PickGame (BOOLEAN saving, BOOLEAN fromMainMenu)
 
 		// These redraw the status of the ship after saving or aborting a load/save
 		DeltaSISGauges(UNDEFINED_DELTA, UNDEFINED_DELTA, UNDEFINED_DELTA); // Redraws fuel, crew, and status message (green box)
-		DrawSISMessage(NULL); // Redraws main title bar at the top-left
-
-		// Redraws secondary title bar to the right of the main bar
-		if (inHQSpace())
-			DrawHyperCoords(GLOBAL(ShipStamp.origin));
-		else if (GLOBAL(ip_planet) == 0)
-			DrawHyperCoords(CurStarDescPtr->star_pt);
+		if (DrawSISBar)
+			DrawSISBar ();
 		else
-			DrawSISTitle(GLOBAL_SIS(PlanetName));
+		{
+			DrawSISMessage(NULL); // Redraws main title bar at the top-left
+
+			// Redraws secondary title bar to the right of the main bar
+			if (inHQSpace())
+				DrawHyperCoords(GLOBAL(ShipStamp.origin));
+			else if (GLOBAL(ip_planet) == 0)
+				DrawHyperCoords(CurStarDescPtr->star_pt);
+			else
+				DrawSISTitle(GLOBAL_SIS(PlanetName));
+		}
 
 		ScreenTransition (3, &DlgRect);
 		UnbatchGraphics ();

--- a/src/uqm/gameopt.h
+++ b/src/uqm/gameopt.h
@@ -30,6 +30,10 @@ typedef void (NamingCallback) (void);
 extern void SetNamingCallback (NamingCallback *);
 extern void AskNameForCaptainAndShip(void);
 
+typedef void (SISBarDrawFunc) (void);
+// The function passed to this, if not null, is called instead when PickGame would normally redraw the SIS message and title with the current location.
+extern void SetSISBarDrawFunc (SISBarDrawFunc *);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/uqm/outfit.c
+++ b/src/uqm/outfit.c
@@ -636,6 +636,13 @@ onNamingDone (void)
 	DrawFlagshipName (FALSE, FALSE);
 }
 
+static void
+DrawLocation (void)
+{
+	DrawSISMessage (GAME_STRING (STARBASE_STRING_BASE + 2));
+	DrawSISTitle (GAME_STRING (STARBASE_STRING_BASE));
+}
+
 BOOLEAN
 DoOutfit (MENU_STATE *pMS)
 {
@@ -648,6 +655,7 @@ DoOutfit (MENU_STATE *pMS)
 		pMS->Initialized = TRUE;
 
 		SetNamingCallback (onNamingDone);
+		SetSISBarDrawFunc (DrawLocation);
 
 		{
 			COUNT num_frames;
@@ -666,8 +674,7 @@ DoOutfit (MENU_STATE *pMS)
 			SetTransitionSource (NULL);
 			BatchGraphics ();
 			DrawSISFrame ();
-			DrawSISMessage (GAME_STRING (STARBASE_STRING_BASE + 2));
-			DrawSISTitle (GAME_STRING (STARBASE_STRING_BASE));
+			DrawLocation ();
 
 			SetContext (SpaceContext);
 
@@ -761,6 +768,7 @@ ExitOutfit:
 			pMS->ModuleFrame = 0;
 
 			SetNamingCallback (NULL);
+			SetSISBarDrawFunc (NULL);
 
 			return (FALSE);
 		}

--- a/src/uqm/shipyard.c
+++ b/src/uqm/shipyard.c
@@ -1506,6 +1506,13 @@ DrawBluePrint (MENU_STATE *pMS)
 	DestroyDrawable (ReleaseDrawable (ModuleFrame));
 }
 
+static void
+DrawLocation (void)
+{
+	DrawSISMessage (GAME_STRING (STARBASE_STRING_BASE + 3));
+	DrawSISTitle (GAME_STRING (STARBASE_STRING_BASE));
+}
+
 BOOLEAN
 DoShipyard (MENU_STATE *pMS)
 {
@@ -1520,6 +1527,8 @@ DoShipyard (MENU_STATE *pMS)
 	if (!pMS->Initialized)
 	{
 		pMS->InputFunc = DoShipyard;
+
+		SetSISBarDrawFunc (DrawLocation);
 
 		{
 			STAMP s;
@@ -1536,8 +1545,7 @@ DoShipyard (MENU_STATE *pMS)
 			SetTransitionSource (NULL);
 			BatchGraphics ();
 			DrawSISFrame ();
-			DrawSISMessage (GAME_STRING (STARBASE_STRING_BASE + 3));
-			DrawSISTitle (GAME_STRING (STARBASE_STRING_BASE));
+			DrawLocation ();
 			SetContext (SpaceContext);
 			DrawBluePrint (pMS);
 
@@ -1584,6 +1592,7 @@ DoShipyard (MENU_STATE *pMS)
 	{
 ExitShipyard:
 		SetInputCallback (NULL);
+		SetSISBarDrawFunc (NULL);
 
 		DestroyDrawable (ReleaseDrawable (pMS->ModuleFrame));
 		pMS->ModuleFrame = 0;


### PR DESCRIPTION
The code to redraw your current location in the top bar after exiting the save or load screen drew "Sol" - "Earth" when at the starbase, when it should draw either "Outfit Starship" - "Starbase" or "Shipyard" - "Starbase". This was causing a crash when exiting the save or load screen at the starbase after being transported from Procyon, since `CurStarDescPtr` is `NULL` at that time.

(I'm not entirely happy with the way I implemented this, but I couldn't think of any better way to do it, and the UQM code already does something similar with `SetNamingCallback`)

[Here's a save that you can test it with](https://github.com/Serosis/UQM-MegaMod/files/3650940/save.zip) (at Procyon with all required devices).