### PR TITLE
Fix positioning of SIS after time passages at starbase and in a no-starbase run at endgame

### DIFF
--- a/src/uqm/comm/chmmr/chmmrc.c
+++ b/src/uqm/comm/chmmr/chmmrc.c
@@ -26,6 +26,8 @@
 			// for SOL_X/SOL_Y
 #include "../../nameref.h"
 			// JMS_GFX: For LoadGraphic 
+#include "../../planets/planets.h"
+			// For MIN_MOON_RADIUS
 
 
 static LOCDATA chmmr_desc =
@@ -154,12 +156,6 @@ ExitConversation (RESPONSE_REF R)
 		GLOBAL (ModuleCost[PLANET_LANDER]) = 0;
 
 #define EARTH_INDEX 2 /* earth is 3rd planet --> 3 - 1 = 2 */
-/* Magic numbers for Earth */
-#define EARTH_INNER_X (121)
-#define EARTH_INNER_Y (113)
-/* Magic numbers for Earth Starbase */
-#define STARBASE_INNER_X (86)
-#define STARBASE_INNER_Y (113)
 
 		/* transport player to Earth */
 		GLOBAL_SIS (log_x) = UNIVERSE_TO_LOGX (SOL_X);
@@ -185,8 +181,9 @@ ExitConversation (RESPONSE_REF R)
 
 			/* XXX : this should be unhardcoded eventually */
 			/* transport to Starbase */
-			GLOBAL (ShipStamp.origin.x) = SIS_SCREEN_WIDTH >> 1;
-			GLOBAL (ShipStamp.origin.y) = SIS_SCREEN_HEIGHT >> 1;
+			/* note: if optOrbitingPlanets is enabled, this will be corrected in DoTimePassage */
+			GLOBAL (ShipStamp.origin.x) = (SIS_SCREEN_WIDTH >> 1) + COSINE(HALF_CIRCLE + QUADRANT, MIN_MOON_RADIUS);
+			GLOBAL (ShipStamp.origin.y) = (SIS_SCREEN_HEIGHT >> 1) + SINE(HALF_CIRCLE + QUADRANT, MIN_MOON_RADIUS >> 1);
 		}
 		else
 		{	/* 'Beating Game Differently' mode - never visited Starbase,
@@ -215,11 +212,6 @@ ExitConversation (RESPONSE_REF R)
 				GLOBAL_SIS (ModuleSlots[i]) = GLOBAL_SIS (ModuleSlots[m]);
 				GLOBAL_SIS (ModuleSlots[m]) = EMPTY_SLOT + 2;
 			}
-
-			/* XXX : this should be unhardcoded eventually */
-			/* transport to Earth itself */
-			GLOBAL (ShipStamp.origin.x) = EARTH_INNER_X;
-			GLOBAL (ShipStamp.origin.y) = EARTH_INNER_Y;
 		}
 
 		/* install Chmmr-supplied modules */

--- a/src/uqm/starbase.c
+++ b/src/uqm/starbase.c
@@ -547,6 +547,7 @@ DoTimePassage (void)
 	MoveGameClockDays (LOST_DAYS);
 
 	// JMS: Calculate flagship location in IP.
+	if (optOrbitingPlanets)
 	{
 		double newAngle;
 		POINT starbase_coords;
@@ -564,21 +565,9 @@ DoTimePassage (void)
 		
 		//log_add (log_Debug, "startangle:%d angle:%f, radius:%d, speed:%f, days:%f X:%d, y:%d", 10, newAngle, MIN_MOON_RADIUS, FULL_CIRCLE / 11.46, daysElapsed(), starbase_coords.x, starbase_coords.y);
 		
-		// Translate the coordinates on a circle to an ellipse.
-		r.corner.x = (SIS_SCREEN_WIDTH >> 1) + (long)-dx;
-		r.corner.y = (SIS_SCREEN_HEIGHT >> 1) + (long)-dy / 2;
-		r.extent.width = (long)MIN_MOON_RADIUS * (2 << 1) / 2;
-		r.extent.height = r.extent.width >> 1;
-		r.corner.x += r.extent.width >> 1;
-		r.corner.y += r.extent.height >> 1;
-		r.corner.x += (long)starbase_coords.x;
-		r.corner.y += (long)starbase_coords.y / 2;
-		
-		//log_add (log_Debug, "X:%d, y:%d", r.corner.x, r.corner.y);
-		
-		// Update the ship's graphics' coordinates on the screen.
-		GLOBAL (ShipStamp.origin.x) = r.corner.x;
-		GLOBAL (ShipStamp.origin.y) = r.corner.y;
+		// Translate the coordinates on a circle to an ellipse and update the ship's graphics' coordinates on the screen.
+		GLOBAL (ShipStamp.origin.x) = (SIS_SCREEN_WIDTH >> 1) + starbase_coords.x;
+		GLOBAL (ShipStamp.origin.y) = (SIS_SCREEN_HEIGHT >> 1) + (starbase_coords.y >> 1);
 	}
 }
 
@@ -687,6 +676,9 @@ void
 InstallBombAtEarth (void)
 {
 	DoTimePassage ();
+
+	GLOBAL (ShipStamp.origin.x) = SIS_SCREEN_WIDTH >> 1;
+	GLOBAL (ShipStamp.origin.y) = SIS_SCREEN_HEIGHT >> 1;
 
 	SetContext (ScreenContext);
 	SetTransitionSource (NULL);


### PR DESCRIPTION
Previously, `DoTimePassage` would always try to compensate for orbits even if they were disabled. Additionally, in a no-starbase run, the ship was always positioned at the starbase's orbited position after transport from Procyon, when it should be positioned over Earth.

I've also simplified some apparently needlessly complicated code in `DoTimePassage` (comments mine):
```c
dx = MIN_MOON_RADIUS;
dy = MIN_MOON_RADIUS;
...
r.corner.x = (SIS_SCREEN_WIDTH >> 1) + (long)-dx;
r.corner.y = (SIS_SCREEN_HEIGHT >> 1) + (long)-dy / 2;
r.extent.width = (long)MIN_MOON_RADIUS * (2 << 1) / 2;
//             = MIN_MOON_RADIUS * 4 / 2
//             = MIN_MOON_RADIUS * 2
r.extent.height = r.extent.width >> 1;
//              = MIN_MOON_RADIUS
r.corner.x += r.extent.width >> 1;
//          = MIN_MOON_RADIUS
// now r.corner.x = SIS_SCREEN_WIDTH >> 1 (Earth's position)
r.corner.y += r.extent.height >> 1;
//          = MIN_MOON_RADIUS / 2
// now r.corner.y = SIS_SCREEN_HEIGHT >> 1 (Earth's position)
```
(I'm not sure why the casts to `long` were there either, as both `MIN_MOON_RADIUS` and `SIS_SCREEN_WIDTH`/`SIS_SCREEN_HEIGHT` are within the range of a 16-bit integer by far - if they weren't, they would overflow the `COORD`s that `r.corner` and `r.extent` use)